### PR TITLE
add code of conduct and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribution Guidelines
+
+## Create an Issue
+
+Before creating an issue, *please search all closed and open issues to make sure that your question has not already been answered*. If that is the case, open an issue and follow the [Issue Template](https://github.com/mantiumai/mantiumclient-py/blob/main/.github/templates/issue_template.md). Please explain any *relevant and necessary* details to the issue.
+
+## Create a Pull Request
+
+In order for us to take the appropriate action with your Pull Request, please use the PR templates from the PR dropdown menu.
+
+Feel free to use and reproduce these templates from our [Pull Request Templates](https://github.com/mantiumai/mantiumclient-py/tree/main/.github/templates).
+
+### Pull Request Guide:
+
+1. Create a personal fork of the repository to your own Github and clone it onto your local machine. Your remote repo is now called `origin`.
+2. Add the original repo (ours) as a remote called `upstream`. Check out [Configuring a Remote For a Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork) if you're unsure of how to do this.
+3. If you have a fork but haven't updated it recently, be sure to pull changes from `upstream`.
+4. Create a branch off of the `main` branch to work on the feature you intend to modify! It is highly recommended that you work on one feature per branch so that any changes can be easily documented and understood.
+To name your branch please use this format: `username-issue#-name-of-feature`
+5. Implement the changes in your branch - please be sure to add any necessary comments and follow the style conventions of our codebase.
+6. Have you run a linter over your code? Do you have tests for it? Please do that now! (*Poetry implementation guide coming soon)*.
+7. Correct any linting or testing errors you may have encountered.
+8. Double check your documentation and update it as necessary.
+9. Squash your commits into one commit - details on how to do that [here](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#:~:text=file%E2%80%9D%20commit%20completely.-,Squashing%20Commits,-It%E2%80%99s%20also%20possible).
+10. Push your branch up to your Github fork (`origin`).
+11. Open a pull request to our project's `main` branch from the correct branch in your fork. Be sure to follow the relevant template.
+12. Once your pull request has been approved and merged, you can then pull from `upstream` into your main local repository and delete the branch(es) to which those changes belonged.
+
+### General Tips for Contributions:
+
+1. Documentation is good! If you made a design choice that may not be obvious, concisely explain why it was done. If you might forget why you made a change when you look at your code later, add a short comment to that change.
+2. Readable code helps everyone - variables should be named descriptively and functions should be as short and modular as possible.
+3. Commit messages should be relevant to the changes made.
+4. Follow code style standards!
+5. If you were asked to make changes in your PR review, request another review once you have applied the necessary changes.
+
+## Questions? Find us on [developer.mantiumai.com](https://developer.mantiumai.com/discuss) or [Discord](https://discord.gg/b4DyRVwC)!

--- a/CoC.md
+++ b/CoC.md
@@ -1,0 +1,67 @@
+
+# Code of Conduct
+
+### **Shorter version**
+
+Mantium is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, visible or invisible disability, physical appearance, body size, religion (or lack thereof), race, socioeconomic status, ethnicity, nationality, or age. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all online and offline Mantium spaces, including our mailing list, social media platforms, online servers, in-person Mantium events, and personal interactions pertaining to Mantium business. Some Mantium spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+
+Violation of this Code of Conduct can result in moderation by Mantium community leaders, suspension or expulsion from Mantium community spaces, and as last resort, being banned from the Mantium community altogether.
+
+### **Longer version**
+
+Mantium is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, visible or invisible disability, physical appearance, body size, religion (or lack thereof), race, socioeconomic status, ethnicity, nationality, or age. We do not tolerate harassment of participants in any form.
+
+This code of conduct applies to all online and offline Mantium spaces, including our mailing list, social media platforms, online servers, in-person Mantium events, and personal interactions pertaining to Mantium business. Some Mantium spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.
+
+Violation of this Code of Conduct can result in moderation by Mantium community leaders, suspension or expulsion from Mantium community spaces, and as last resort, being banned from the Mantium community altogether.
+
+Harassment includes, but is not limited to:
+
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion.
+- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+- Deliberate misgendering or use of ‘dead’ or rejected names.
+- Inappropriate and/or unwelcome sexual behaviors, images, or content in public and private interactions.
+- Threats of violence.
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.
+- Deliberate intimidation.
+- Stalking or following.
+- Harassing photography or recording, including logging online activity for harassment purposes.
+- Spamming, trolling, or any sustained disruptive behavior in discussions.
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others.
+- Continued one-on-one communication after requests to cease.
+- Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse.
+- Publication of non-harassing private communication.
+
+Mantium prioritizes marginalized people’s safety over privileged people’s comfort. At their discretion, Mantium moderators reserve the right to not act on the following:
+
+- ‘Reverse’ -isms, including "reverse racism," "reverse sexism," or "cisphobia."
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+- Communicating in a "tone" you don’t find congenial (this does not include harassment).
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.
+- Any complaint that the Mantium moderator team determines to have been made in bad faith or in an attempt to harass another community member.
+
+In order to protect the moderation team from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
+
+### **Reporting**
+
+If you are being harassed by any Mantium community member, including members of staff, notice that someone else is being harassed, or have any other concerns, please contact the Mantium moderators. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+
+This code of conduct applies to Mantium spaces, but if you are being harassed by a member of Mantium outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Mantium members (including and especially moderators) seriously. This includes harassment outside our spaces and harassment prior to becoming a Mantium community member. Mantium moderators reserve the right to vet users based on their past behavior, including behavior outside Mantium spaces and behavior towards people who are not in the Mantium community.
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse or harassment. At our discretion, we may privately warn about or publicly name those guilty of harassment in the Mantium spaces if we believe that doing so will increase the safety of Mantium members or the general public. We will never name harassment victims without their affirmative consent.
+
+### **Consequences**
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behavior, Mantium moderators may take any action they deem appropriate, up to and including expulsion from all Mantium spaces and events as well as identifying the harasser to the Mantium community in order to protect our community members.
+
+
+Sources:
+
+- [GitHub - Building Communities](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
+- [Geek Feminism](https://geekfeminism.wikia.org/wiki/Community_anti-harassment/Policy)
+- [Nexosis](https://github.com/Nexosis/community-code-of-conduct/blob/master/long-form-code-of-conduct.md#long-form-code-of-conduct)
+- [Contributor Covenant](https://www.contributor-covenant.org/)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ query_request = {'query': 'What should I have for dinner tonight?'}
 return apps_api.query_application(application_id, query_request)
 ```
 
+## Contributing / Code of Conduct
+
+- Find our contributing guide [here](CONTRIBUTING.md).
+- Find our Code of Conduct [here](CoC.md). 
+
 ## License
 
 [Apache-2.0](https://choosealicense.com/licenses/apache-2.0/)


### PR DESCRIPTION
I had created a code of conduct and contribution guide for our old mantium client project [here](https://github.com/mantiumai/mantiumclient-py/blob/main/.github/CoC.md) and thought it would be useful to bring these over to the new project, as we also link to the CoC from our Discord server. Please feel free to reject or modify as you see fit! 