### PR TITLE
Kbs add identify as to api

### DIFF
--- a/mantium_client/api_client.py
+++ b/mantium_client/api_client.py
@@ -33,6 +33,7 @@ class MantiumClient(ApiClient):
 
         self.host = os.getenv('ROOT_URL', 'https://api2.mantiumai.com')
         self.client_side_validation = False
+        self.user_email: str | None = None
 
     def get_token(self) -> str:
         """Get a token from the Mantium API."""

--- a/mantium_client/api_client.py
+++ b/mantium_client/api_client.py
@@ -74,7 +74,7 @@ class MantiumClient(ApiClient):
         self.access_token = None
         self.get_token()
 
-    def identify_as(self, user_email: str | None) -> None:
+    def identify_as(self, user_email: str) -> None:
         """Identify as a user in your org by email.
 
         This will only work if you're an organization owner, and the user is in your organization.

--- a/mantium_client/api_client.py
+++ b/mantium_client/api_client.py
@@ -73,6 +73,14 @@ class MantiumClient(ApiClient):
         self.access_token = None
         self.get_token()
 
+    def identify_as(self, user_email: str | None) -> None:
+        """Identify as a user in your org by email.
+
+        This will only work if you're an organization owner, and the user is in your organization.
+        Pass in None to stop impersonating.
+        """
+        self.user_email = user_email
+
     def call_api(self, *args: Any, **kwargs: Any) -> tuple:
         """Call the API with the given args and kwargs."""
         resource_path, method, path_params, query_params, header_params = args
@@ -84,7 +92,8 @@ class MantiumClient(ApiClient):
 
         access_token = self.get_token()
         header_params.update({'Authorization': f'{access_token}', 'User-Agent': 'mantium_client-mantium-py/' + version})
-
+        if self.user_email:
+            header_params.update({'substitute-user': self.user_email})
         retryer = Retrying(
             reraise=True,
             wait=wait_fixed(2),

--- a/mantium_client/api_client.py
+++ b/mantium_client/api_client.py
@@ -33,7 +33,7 @@ class MantiumClient(ApiClient):
 
         self.host = os.getenv('ROOT_URL', 'https://api2.mantiumai.com')
         self.client_side_validation = False
-        self.user_email: str | None = None
+        self.user_email = None
 
     def get_token(self) -> str:
         """Get a token from the Mantium API."""


### PR DESCRIPTION
Just passes along an email in the header for people trying to use impersonation on the query routes.